### PR TITLE
feat: update collection endpoints

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
                .library(name: "SwiftagramCrypto",
                         targets: ["SwiftagramCrypto"])],
     // Package dependencies.
-    dependencies: [.package(url: "https://github.com/sbertix/ComposableRequest", .upToNextMinor(from: "5.2.1")),
+    dependencies: [.package(url: "https://github.com/sbertix/ComposableRequest", .upToNextMinor(from: "5.3.1")),
                    .package(url: "https://github.com/sbertix/SwCrypt.git", .upToNextMinor(from: "5.1.0"))],
     // All targets.
     targets: [.target(name: "Swiftagram",

--- a/Sources/Swiftagram/Endpoints/Endpoint.swift
+++ b/Sources/Swiftagram/Endpoints/Endpoint.swift
@@ -9,21 +9,17 @@ import Foundation
 
 /// A module-like `enum` defining all possible `Endpoint`s.
 public enum Endpoint {
+    // swiftlint:disable line_length
     /// An `Endpoint` allowing for a paginated request with a custom `Response` value.
     ///
     /// - note: Always reference this alias, to abstract away `ComposableRequest` implementation.
-    public typealias Paginated < Response,
-                               Offset,
-                               Failure: Error> = LockSessionPagerProvider < Secret,
-                                                                          Offset,
-                                                                          AnyPublisher<Response, Failure>>
+    public typealias Paginated<Response, Offset, Failure: Error> = LockSessionPagerProvider<Secret, Offset, AnyPublisher<Response, Failure>>
+    // swiftlint:enable line_length
 
     /// An `Endpoint` allowing for a single request with a custom `Response` value.
     ///
     /// - note: Always reference this alias, to abstract away `ComposableRequest` implementation.
-    public typealias Single < Response,
-                            Failure: Error> = LockSessionProvider < Secret,
-                                                                  AnyPublisher<Response, Failure>>
+    public typealias Single<Response, Failure: Error> = LockSessionProvider<Secret, AnyPublisher<Response, Failure>>
 
     /// A module-like `enum` to hide away endpoint wrappers definitions.
     public enum Group { }

--- a/Sources/Swiftagram/Endpoints/Saved/Endpoint+SavedCollection.swift
+++ b/Sources/Swiftagram/Endpoints/Saved/Endpoint+SavedCollection.swift
@@ -57,7 +57,7 @@ public extension Endpoint.Group.Saved.Collection {
 }
 
 public extension Endpoint.Group.Saved.Collection {
-    /// All posts inside the collection.
+    /// A summary of the collection.
     ///
     /// - note: Prefer `Endpoint.posts.saved.collection(_:)`.
     var summary: Endpoint.Paginated<SavedCollection.Unit, String?, Swift.Error> {

--- a/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
+++ b/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
@@ -72,6 +72,16 @@ public extension SavedCollection {
         /// The collection.
         public var collection: SavedCollection? { self["saveMediaResponse"].optional().flatMap(SavedCollection.init) }
 
+        /// Media in the response.
+        ///
+        /// - note: Only populated when fetching posts and igtvs.
+        public var items: [Media]? {
+            self["items"].array()?.compactMap {
+                $0.media.optional().flatMap(Media.init) ??
+                  $0.optional().flatMap(Media.init)
+            }
+        }
+
         /// The offset.
         public var offset: String? {
             self["saveMediaResponse"].nextMaxId.string(converting: true) ?? self["nextMaxId"].string(converting: true) ??

--- a/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
+++ b/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
@@ -39,8 +39,8 @@ public struct SavedCollection: Wrapped {
     /// Media in the response.
     ///
     /// - note: Only populated when fetching a single collection.
-    public var items: [Media]? { self["items"].array()?.compactMap(Media.init) }
-
+     public var items: [Media]? { self["items"].array()?.compactMap { $0.media.optional().flatMap(Media.init) } }
+    
     /// Init.
     /// - parameter wrapper: A valid `Wrapper`.
     public init(wrapper: @escaping () -> Wrapper) {

--- a/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
+++ b/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
@@ -74,7 +74,8 @@ public extension SavedCollection {
 
         /// The offset.
         public var offset: String? {
-            self["saveMediaResponse"].nextMaxId.string(converting: true) ?? self["nexMaxId"].string(converting: true)
+            self["saveMediaResponse"].nextMaxId.string(converting: true) ?? self["nextMaxId"].string(converting: true) ??
+                self["maxId"].string(converting: true)
         }
 
         /// Init.

--- a/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
+++ b/Sources/Swiftagram/Models/Specialized/SavedCollection.swift
@@ -31,7 +31,10 @@ public struct SavedCollection: Wrapped {
     /// The cover media items.
     ///
     /// - note: Only populated when fetching all collections.
-    public var cover: [Media]? { self["coverMediaList"].array()?.compactMap(Media.init) }
+    public var cover: [Media]? {
+        self["coverMediaList"].array()?.compactMap(Media.init) ??
+          self["coverMedia"].optional().flatMap{ [Media.init(wrapper: $0)] }
+    }
 
     /// Media in the response.
     ///

--- a/Tests/SwiftagramTests/EndpointTests.swift
+++ b/Tests/SwiftagramTests/EndpointTests.swift
@@ -526,6 +526,24 @@ internal final class EndpointTests: XCTestCase {
     }
     // swiftlint:enable function_body_length
 }
+
+private extension Media.Content {
+  func images() -> [Media.Version]? {
+    var images: [Media.Version]? {
+      switch self {
+      case .picture(let pic):
+        return pic.images
+      case .video(let vid):
+        return vid.images
+      case .album(let album):
+        return album.first?.images()
+      default:
+        return Optional.none
+      }
+    }
+    return images
+  }
+}
 // swiftlint:enable file_length
 // swiftlint:enable type_body_length
 

--- a/Tests/SwiftagramTests/EndpointTests.swift
+++ b/Tests/SwiftagramTests/EndpointTests.swift
@@ -378,6 +378,93 @@ internal final class EndpointTests: XCTestCase {
         performTest(on: Endpoint.posts
                         .saved,
                     "Endpoint.Saved.posts")
+        if let collections = performTest(on: Endpoint.saved
+                                            .collections,
+                                        "Endpoint.Saved.collections")?.collections {
+            XCTAssertEqual(collections.first?.identifier, "ALL_MEDIA_AUTO_COLLECTION")
+            let firstCoverURL = collections.first?.cover?.first?.content.images()?.first?.url
+            XCTAssertNotNil(firstCoverURL, "Couldn't find \"All Posts\" first cover")
+            
+            XCTAssertGreaterThan(collections.count, 1, "Test set requires a saved collection")
+            let userCollection = collections[2]
+            let userCoverURL = userCollection.cover?.first?.content.images()?.first?.url
+            XCTAssertNotNil(userCoverURL, "Couldn't find first user collection first cover")
+
+            var hugeCollectionExists = false
+            for collection in collections[1...] {
+                if let summary = performTest(on: Endpoint.saved.collection(collection.identifier),
+                                             "Endpoint.saved.collection"),
+                   let offset = summary.offset {
+                    
+                    guard let collection = summary.collection,
+                          let firstItemID = collection.items?.first?.identifier else { XCTFail("Incorrect collection decoding"); return }
+                    
+                    let userCoverURL = collection.items?.first?.content.images()?.first?.url
+                    XCTAssertNotNil(userCoverURL, "Couldn't find collection first cover")
+                        
+                    // test all/ with an offset
+                    if let summaryMore = performTest(on: Endpoint.saved.collection(collection.identifier),
+                                                   "Endpoint.saved.collection", offset: offset) {
+                        guard let npFirstItemID = summaryMore.collection?.items?.first?.identifier else {
+                        XCTFail("Incorrect Offset-Fetched Collection decoding"); return }
+                        
+                        let imageURL = summaryMore.collection?.items?.first?.content.images()?.first?.url
+                        XCTAssertNotNil(imageURL, "Couldn't find post first image")
+                        
+                        XCTAssertEqual(firstItemID, npFirstItemID, "Instagram API changed and now interprets max_id for all/")
+                    }
+
+                    // test posts/ with an offset
+                    if let morePosts = performTest(on: Endpoint.saved.collection(collection.identifier).posts,
+                                                   "Endpoint.saved.collection.posts", offset: offset) {
+                        guard let mpFirstItemID = morePosts.items?.first?.identifier else { XCTFail("Incorrect Offset-Fetched Post Collection decoding"); return }
+                        
+                        let imageURL = morePosts.items?.first?.content.images()?.first?.url
+                        XCTAssertNotNil(imageURL, "Couldn't find post first image")
+                        
+                        XCTAssertNotEqual(firstItemID, mpFirstItemID, "Failure to Offset-Fetch Post Collection")
+
+                        if let offset = morePosts.offset {
+                            hugeCollectionExists = true
+                            
+                            if let yetMorePosts = performTest(on: Endpoint.saved.collection(collection.identifier).posts,
+                                                              "Endpoint.saved.collection.posts", offset: offset) {
+                                guard let ympFirstItemID = yetMorePosts.items?.first?.identifier else { XCTFail("Incorrect Offset²-Fetched Post Collection decoding"); return }
+                                
+                                let imageURL = yetMorePosts.items?.first?.content.images()?.first?.url
+                                XCTAssertNotNil(imageURL, "Couldn't find post first image")
+                                
+                                XCTAssertNotEqual(firstItemID, ympFirstItemID, "Failure to Offset²-Fetch Post Collection")
+                                XCTAssertNotEqual(mpFirstItemID, ympFirstItemID, "Failure to Offset²-Fetch Post Collection")
+                            }
+                        }
+                    }
+                }
+                if hugeCollectionExists { break }
+            }
+            XCTAssertTrue(hugeCollectionExists, "Test set requires a collection with over 42 saved posts")
+            
+            var largeIGTVExists = false
+            for collection in collections[1...] {
+                if let igtvs = performTest(on: Endpoint.saved.collection(collection.identifier).igtv,
+                                             "Endpoint.saved.collection.igtv"),
+                   let offset = igtvs.offset {
+                    largeIGTVExists = true
+
+                    guard let firstItemID = igtvs.items?.first?.identifier else { XCTFail("Incorrect igtv decoding"); return }
+
+                    if let nextIgtvs = performTest(on: Endpoint.saved.collection(collection.identifier).igtv,
+                                                   "Endpoint.saved.collection.igtv", offset: offset) {
+                        guard let niFirstItemID = nextIgtvs.items?.first?.identifier else { XCTFail("Incorrect Offset-Fetched Post Collection decoding"); return }
+
+                        XCTAssertNotEqual(firstItemID, niFirstItemID, "Failure to Offset-Fetch igtv Collection")
+                    }
+                }
+                if largeIGTVExists { break }
+            }
+            XCTAssertTrue(largeIGTVExists, "Test set requires a collection with over 21 saved igtv")
+        }
+            
         if let collection = performTest(on: Endpoint.saved
                                             .collections,
                                         "Endpoint.Saved.collections")?.collections?.last {

--- a/Tests/SwiftagramTests/EndpointTests.swift
+++ b/Tests/SwiftagramTests/EndpointTests.swift
@@ -116,6 +116,7 @@ internal final class EndpointTests: XCTestCase {
     private func performTest<W: Wrappable, P, E: Error>(on endpoint: Endpoint.Paginated<W, P, E>,
                                                         _ identifier: String,
                                                         pages: Int = 1,
+                                                        offset: P = .init(offset: .composableNone, rank: .composableNone),
                                                         logging level: Logger = .default,
                                                         line: Int = #line) -> W?
     where P: Ranked, P.Offset: ComposableOptionalType, P.Rank: ComposableOptionalType {
@@ -128,7 +129,7 @@ internal final class EndpointTests: XCTestCase {
         let reference = Reference<W?>(nil)
         endpoint.unlock(with: secret)
             .session(.instagram, logging: level)
-            .pages(pages)
+            .pages(pages, offset: offset)
             .sink(
                 receiveCompletion: {
                     if case .failure(let error) = $0 { XCTFail(error.localizedDescription + " \(identifier) #\(line)") }
@@ -150,6 +151,7 @@ internal final class EndpointTests: XCTestCase {
     private func performTest<W: Wrappable, P, E: Error>(on endpoint: Endpoint.Paginated<W, P, E>,
                                                         _ identifier: String,
                                                         pages: Int = 1,
+                                                        offset: P = .composableNone,
                                                         logging level: Logger = .default,
                                                         line: Int = #line) -> W?
     where P: ComposableOptionalType {
@@ -162,7 +164,7 @@ internal final class EndpointTests: XCTestCase {
         let reference = Reference<W?>(nil)
         endpoint.unlock(with: secret)
             .session(.instagram, logging: level)
-            .pages(pages)
+            .pages(pages, offset: offset)
             .sink(
                 receiveCompletion: {
                     if case .failure(let error) = $0 { XCTFail(error.localizedDescription + " \(identifier) #\(line)") }


### PR DESCRIPTION
* [`36e37a6`](http://github.com/sbertix/Swiftagram/commit/36e37a6ac855ce366f940c14aae128576cc2aff7) - fix(endpoints): simplify timeline definition
* [`13b2e45`](http://github.com/sbertix/Swiftagram/commit/13b2e45438e0ecdfac5124f0a810669dbfc4f001) - fix cover accessor to work with all collections
* [`fea3e5a`](http://github.com/sbertix/Swiftagram/commit/fea3e5a8e7c7815f28a7ec41838fe2b924eb1c51) - fix items when accessing a collection summary
* [`060b7a6`](http://github.com/sbertix/Swiftagram/commit/060b7a645f635c512d6e6f71ae4719f9a1316160) - fix offset accessor
* [`175b25f`](http://github.com/sbertix/Swiftagram/commit/175b25f2c98b40cd2d4e50da24e1196fb9d9fd87) - added items accessor for posts & igtv
* [`72cc38d`](http://github.com/sbertix/Swiftagram/commit/72cc38d77e2e4c61b4aa48ab07dae20f5606a0e0) - Fix summary description
* [`9932c7c`](http://github.com/sbertix/Swiftagram/commit/9932c7c4652ad204cab417fa5ef2364fef5c5590) - Added posts and igtv
* [`f1b713c`](http://github.com/sbertix/Swiftagram/commit/f1b713c2941ecdc47dad1a99f9f7694bd2411a80) - performTest on Paginated.Endpoints accept offset
* [`a05f1f1`](http://github.com/sbertix/Swiftagram/commit/a05f1f170668096122f7720af0b7be7e649d0ff0) - Media.Content helper func to access the images
* [`4b7d4d3`](http://github.com/sbertix/Swiftagram/commit/4b7d4d337c86cf7291e641b2646d3332e4bbffe3) - Added collection tests
* [`85a6b40`](http://github.com/sbertix/Swiftagram/commit/85a6b4073e1cb0492fc949eb8f1fab7460483a02) - Merge branch 'sbertix:main' into collections