### PR TITLE
fix: fix checking for empty values for 2fa.

### DIFF
--- a/Sources/SwiftagramCrypto/Authentication/Basic/Authenticator+TwoFactor.swift
+++ b/Sources/SwiftagramCrypto/Authentication/Basic/Authenticator+TwoFactor.swift
@@ -72,7 +72,7 @@ public extension Authenticator.Group.Basic {
                 .publish(session: .ephemeral)
                 .tryMap { result throws -> Secret in
                     let value = try Wrapper.decode(result.data)
-                    guard value.isEmpty, let response = result.response as? HTTPURLResponse else {
+                    guard !value.isEmpty, let response = result.response as? HTTPURLResponse else {
                         throw Authenticator.Error.invalidResponse(result.response)
                     }
                     // Prepare the actual `Secret`.


### PR DESCRIPTION
* [`505c32f`](http://github.com/sbertix/Swiftagram/commit/505c32f91f1a73bf0aa4d86d3b2280b4be1ef4a4) - fix: fix checking for empty values for 2fa.