### PR TITLE
fix: fix checking for empty values for 2fa

### DIFF
--- a/Sources/SwiftagramCrypto/Authentication/Basic/Authenticator+TwoFactor.swift
+++ b/Sources/SwiftagramCrypto/Authentication/Basic/Authenticator+TwoFactor.swift
@@ -72,7 +72,7 @@ public extension Authenticator.Group.Basic {
                 .publish(session: .ephemeral)
                 .tryMap { result throws -> Secret in
                     let value = try Wrapper.decode(result.data)
-                    guard value.isEmpty, let response = result.response as? HTTPURLResponse else {
+                    guard !value.isEmpty, let response = result.response as? HTTPURLResponse else {
                         throw Authenticator.Error.invalidResponse(result.response)
                     }
                     // Prepare the actual `Secret`.


### PR DESCRIPTION
* [`c7f4438`](http://github.com/sbertix/Swiftagram/commit/c7f44385e56ecc68cd1973a5e9c57ec37bacc6a9) - fix: fix checking for empty values for 2fa