### PR TITLE
fix: update checking for empty values for 2fa

### DIFF
--- a/Sources/SwiftagramCrypto/Authentication/Basic/Authenticator+TwoFactor.swift
+++ b/Sources/SwiftagramCrypto/Authentication/Basic/Authenticator+TwoFactor.swift
@@ -72,7 +72,7 @@ public extension Authenticator.Group.Basic {
                 .publish(session: .ephemeral)
                 .tryMap { result throws -> Secret in
                     let value = try Wrapper.decode(result.data)
-                    guard value.isEmpty, let response = result.response as? HTTPURLResponse else {
+                    guard !value.isEmpty, let response = result.response as? HTTPURLResponse else {
                         throw Authenticator.Error.invalidResponse(result.response)
                     }
                     // Prepare the actual `Secret`.

--- a/Tests/SwiftagramTests/EndpointTests.swift
+++ b/Tests/SwiftagramTests/EndpointTests.swift
@@ -627,8 +627,5 @@ internal final class EndpointTests: XCTestCase {
     }
     // swiftlint:enable function_body_length
 }
-// swiftlint:enable file_length
-// swiftlint:enable function_body_length
-// swiftlint:enable type_body_length
 
 #endif


### PR DESCRIPTION
* [`4a72653`](http://github.com/sbertix/Swiftagram/commit/4a72653773ddb9a32cedcc9454593574702973e0) - fix: update checking for empty values for 2fa